### PR TITLE
Fix repository name after transfer to tarantool/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Test](https://github.com/rosik/setup-tarantool/workflows/Test/badge.svg)
+![Test](https://github.com/tarantool/setup-tarantool/workflows/Test/badge.svg)
 
 # Setup Tarantool
 
@@ -16,7 +16,7 @@ This action will set up [Tarantool](https://www.tarantool.io) environment and **
 ```yaml
 steps:
   - uses: actions/checkout@v2
-  - uses: rosik/setup-tarantool@v1
+  - uses: tarantool/setup-tarantool@v1
     with:
       tarantool-version: '2.5'
   - run: tarantoolctl rocks install luatest
@@ -34,7 +34,7 @@ If you need to drop the cache, it's customizable:
 
 ```yaml
 steps:
-  - uses: rosik/setup-tarantool@v1
+  - uses: tarantool/setup-tarantool@v1
     with:
       tarantool-version: 2.5
       cache-key: some-other-key

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ga-test-public",
+  "name": "setup-tarantool",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ga-test-public",
+  "name": "setup-tarantool",
   "version": "1.0.0",
   "description": "",
   "main": "dist/main/index.js",
@@ -10,15 +10,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rosik/ga-test-public.git"
+    "url": "git+https://github.com/tarantool/setup-tarantool.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/rosik/ga-test-public/issues"
+    "url": "https://github.com/tarantool/setup-tarantool/issues"
   },
-  "homepage": "https://github.com/rosik/ga-test-public#readme",
+  "homepage": "https://github.com/tarantool/setup-tarantool#readme",
   "dependencies": {
     "@actions/cache": "^1.0.4",
     "@actions/core": "^1.2.6",


### PR DESCRIPTION
The repository was initially developed by Yaroslav Dynnikov and it was
present within his personal repositories list. Now we found it useful
and moved to the Tarantool's GitHub organization.