### PR TITLE
Update tarantool if there is more fresh version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,19 +9,41 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-20.04]
-        tarantool: ['1.10', '2.4', '2.5', '2.6', '2.7']
+        tarantool:
+          - '1.10'
+          - '2.4'
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - '2.8'
         include:
         - {runs-on: ubuntu-18.04, tarantool: '1.10'}
         - {runs-on: ubuntu-16.04, tarantool: '1.10'}
     runs-on: ${{ matrix.runs-on }}
+    env:
+      TARANTOOL_CACHE_KEY_SUFFIX: -${{ github.run_id }}
     steps:
       - uses: actions/checkout@v2
+
+      - id: get-latest
+        run: |
+          node <<'SCRIPT'
+            process.env["INPUT_TARANTOOL-VERSION"] = "${{ matrix.tarantool }}"
+            require("./dist/main").latest_version().then(v => {
+              console.log(v)
+              console.log(`::set-output name=version::${v}`)
+            })
+          SCRIPT
 
       - name: Setup from scratch
         uses: ./
         with:
           tarantool-version: ${{ matrix.tarantool }}
-          cache-key: tarantool-${{ matrix.tarantool }}-${{ matrix.runs-on }}-${{ github.run_id }}
+
+      - name: Check precise version
+        run: |
+          dpkg -s tarantool | grep '^Version: ${{ steps.get-latest.outputs.version }}'
+          # It'll also fail if tarantool is installed from cache but not from apt-get
 
       - name: Uninstall tarantool
         run: sudo apt-get -y remove tarantool tarantool-dev tarantool-common
@@ -30,9 +52,8 @@ jobs:
         uses: ./
         with:
           tarantool-version: ${{ matrix.tarantool }}
-          cache-key: tarantool-${{ matrix.tarantool }}-${{ matrix.runs-on }}-${{ github.run_id }}
 
-      - name: Check version
+      - name: Check branch version
         run: |
           T=$(tarantool -e 'print(_TARANTOOL:match("%d+%.%d+")); os.exit()')
           if [ "$T" != "${{ matrix.tarantool }}" ]; then
@@ -48,10 +69,11 @@ jobs:
       matrix:
         runs-on: [ubuntu-20.04, ubuntu-20.04, ubuntu-20.04]
     runs-on: ${{ matrix.runs-on }}
+    env:
+      TARANTOOL_CACHE_KEY_SUFFIX: -${{ github.run_id }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Tarantool
         uses: ./
         with:
           tarantool-version: '1.10'
-          cache-key: test-concurrency-${{ github.run_id }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This action will set up [Tarantool](https://www.tarantool.io) environment and **
 - When cached, it takes \~1-2s to finish.
 - The first run takes \~40s.
 - Cache size is \~20MB.
-- Runs on `ubuntu-*` only.
+- Runs on GitHub-hosted `ubuntu-*` runners only.
 
 # Usage
 
@@ -18,26 +18,10 @@ steps:
   - uses: actions/checkout@v2
   - uses: tarantool/setup-tarantool@v1
     with:
-      tarantool-version: '2.5'
+      tarantool-version: '2.6'
   - run: tarantoolctl rocks install luatest
   - run: tarantoolctl rocks make
   - run: .rocks/bin/luatest -v
-```
-
-### Custom cache key
-
-By default, the action caches installed apt packages with the key:
-
-```tarantool-setup-${tarantool-version}-${ubuntu-version}```
-
-If you need to drop the cache, it's customizable:
-
-```yaml
-steps:
-  - uses: tarantool/setup-tarantool@v1
-    with:
-      tarantool-version: 2.5
-      cache-key: some-other-key
 ```
 
 # License

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,8 @@ inputs:
   tarantool-version:
     description: Tarantool version
   cache-key:
-    description: Custom key used for APT packages caching
+    description: Deprecated. Custom key used for APT packages caching
     required: false
 runs:
   using: 'node12'
-  main: dist/main/index.js
+  main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,1 @@
+require("./main").run()

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,10 @@ import * as io from '@actions/io'
 import * as path from 'path'
 import * as fs from 'fs'
 
+const baseUrl =
+  'https://download.tarantool.org/tarantool/release/' +
+  core.getInput('tarantool-version', {required: true})
+
 interface CaptureOptions {
   /** optional.  defaults to false */
   silent?: boolean
@@ -27,6 +31,24 @@ async function capture(cmd: string, options?: CaptureOptions): Promise<string> {
   return output.trim()
 }
 
+let _lsb_release: Promise<string>
+async function lsb_release(): Promise<string> {
+  if (!_lsb_release) {
+    _lsb_release = capture('lsb_release -c -s', {silent: true})
+  }
+
+  return _lsb_release
+}
+
+let _httpc: httpm.HttpClient
+async function http_get(url: string): Promise<httpm.HttpClientResponse> {
+  if (!_httpc) {
+    _httpc = new httpm.HttpClient('httpc')
+  }
+  core.info('HTTP GET ' + url)
+  return _httpc.get(url)
+}
+
 async function dpkg_list(): Promise<Set<string>> {
   const cmd = 'sudo dpkg-query -W -f "${binary:Package}\\n"'
   const output: string = await capture(cmd, {silent: true})
@@ -36,15 +58,60 @@ async function dpkg_list(): Promise<Set<string>> {
   return ret
 }
 
+function semver_max(a: string, b: string): string {
+  const re = /[.-]/
+  var pa = a.split(re)
+  var pb = b.split(re)
+  for (var i = 0; ; i++) {
+    var na = Number(pa[i])
+    var nb = Number(pb[i])
+    if (na > nb) return a
+    if (nb > na) return b
+    if (!isNaN(na) && isNaN(nb)) return a
+    if (isNaN(na) && !isNaN(nb)) return b
+    if (isNaN(na) && isNaN(nb)) return pa[i] >= pb[i] ? a : b
+  }
+}
+
+export async function latest_version(): Promise<string> {
+  const repo = baseUrl + '/ubuntu/dists/' + (await lsb_release())
+  return http_get(`${repo}/main/binary-amd64/Packages`)
+    .then(response => {
+      if (response.message.statusCode !== 200) {
+        throw new Error(`server replied ${response.message.statusCode}`)
+      }
+      return response.readBody()
+    })
+    .then(output => {
+      let ret = ''
+      output
+        .split('\n\n')
+        .filter(paragraph => paragraph.startsWith('Package: tarantool\n'))
+        .forEach(paragraph => {
+          const match = paragraph.match(/^Version: (.+)$/m)
+          const version = match ? match[1] : ret
+          ret = semver_max(ret, version)
+        })
+      return ret
+    })
+}
+
 async function run_linux(): Promise<void> {
   try {
-    const httpc = new httpm.HttpClient('httpc')
-    const t_version = core.getInput('tarantool-version', {required: true})
-    const lsb_release = await capture('lsb_release -c -s', {silent: true})
+    const distro = await lsb_release()
     const cache_dir = 'cache-tarantool'
-    const cache_key =
-      core.getInput('cache-key') ||
-      `tarantool-setup-${t_version}-${lsb_release}`
+
+    core.startGroup('Checking latest tarantool version')
+    const version = await latest_version()
+    core.info(`${version}`)
+    core.endGroup()
+
+    if (core.getInput('cache-key')) {
+      core.warning("Setup-tarantool input 'cache-key' is deprecated")
+    }
+    let cache_key = `tarantool-setup-${distro}-${version}`
+    // This for testing only
+    cache_key += process.env['TARANTOOL_CACHE_KEY_SUFFIX'] || ''
 
     if (await cache.restoreCache([cache_dir], cache_key)) {
       core.info(`Cache restored from key: ${cache_key}`)
@@ -55,16 +122,10 @@ async function run_linux(): Promise<void> {
       core.info(`Cache not found for input key: ${cache_key}`)
     }
 
-    const baseUrl =
-      'https://download.tarantool.org/tarantool/release/' + t_version
-
     await core.group('Adding gpg key', async () => {
-      const url = baseUrl + '/gpgkey'
-      core.info('curl ' + url)
-
-      const response = await httpc.get(url)
+      const response = await http_get(baseUrl + '/gpgkey')
       if (response.message.statusCode !== 200) {
-        throw new Error('server replied ${response.message.statusCode}')
+        throw new Error(`server replied ${response.message.statusCode}`)
       }
 
       const gpgkey = Buffer.from(await response.readBody())
@@ -73,7 +134,7 @@ async function run_linux(): Promise<void> {
 
     await core.group('Setting up repository', async () => {
       await exec.exec('sudo tee /etc/apt/sources.list.d/tarantool.list', [], {
-        input: Buffer.from(`deb ${baseUrl}/ubuntu/ ${lsb_release} main\n`)
+        input: Buffer.from(`deb ${baseUrl}/ubuntu/ ${distro} main\n`)
       })
     })
 
@@ -121,7 +182,7 @@ async function run_linux(): Promise<void> {
   }
 }
 
-async function run(): Promise<void> {
+export async function run(): Promise<void> {
   if (process.platform === 'linux') {
     await run_linux()
   } else {
@@ -130,7 +191,3 @@ async function run(): Promise<void> {
 
   await exec.exec('tarantool --version')
 }
-
-run()
-
-export default run


### PR DESCRIPTION
The patch resolves the problem described in https://github.com/tarantool/setup-tarantool/issues/9#issuecomment-762809256.

Once a version is installed it's cached. A user could drop the cache manually (by updating the `cache-key`), but it should be automated.

This patch changes the caching logic. The `cache-key` input is deprecated. Instead, it's generated and includes a precise deb package version which is obtained by parsing repo content manually:

```js
http_get("https://download.tarantool.org/tarantool/release/2.6" +
  "/ubuntu/dists/focal/main/binary-amd64/Packages"
)
```

It doesn't waste too much time and allows us to reinstall tarantool from apt-get when the new version is out.

The resulting `cache-key` looks like `tarantool-setup-focal-2.8.0.0.gefc30ccf8-1`.
