### PR TITLE
Add an option to install nightly build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,14 @@ jobs:
           - '2.6'
           - '2.7'
           - '2.8'
+          - '2.9'
+        nightly: [false]
         include:
-        - {runs-on: ubuntu-18.04, tarantool: '1.10'}
-        - {runs-on: ubuntu-16.04, tarantool: '1.10'}
+        - {runs-on: ubuntu-18.04, tarantool: '1.10', nightly: true}
+        - {runs-on: ubuntu-16.04, tarantool: '1.10', nightly: true}
     runs-on: ${{ matrix.runs-on }}
     env:
-      TARANTOOL_CACHE_KEY_SUFFIX: -${{ github.run_id }}
+      TARANTOOL_CACHE_KEY_SUFFIX: -A-${{ github.run_id }}
     steps:
       - uses: actions/checkout@v2
 
@@ -29,6 +31,7 @@ jobs:
         run: |
           node <<'SCRIPT'
             process.env["INPUT_TARANTOOL-VERSION"] = "${{ matrix.tarantool }}"
+            process.env["INPUT_NIGHTLY-BUILD"] = "${{ matrix.nightly }}"
             require("./dist/main").latest_version().then(v => {
               console.log(v)
               console.log(`::set-output name=version::${v}`)
@@ -39,6 +42,7 @@ jobs:
         uses: ./
         with:
           tarantool-version: ${{ matrix.tarantool }}
+          nightly-build: ${{ matrix.nightly }}
 
       - name: Check precise version
         run: |
@@ -52,6 +56,15 @@ jobs:
         uses: ./
         with:
           tarantool-version: ${{ matrix.tarantool }}
+          nightly-build: ${{ matrix.nightly }}
+
+      - name: Verify install from cache
+        run: |
+          # Fail if tarantool is installed from apt-get
+          if dpkg -s tarantool; then
+            echo "Tarantool wasn't restored from cache"
+            exit 1
+          fi
 
       - name: Check branch version
         run: |
@@ -70,7 +83,7 @@ jobs:
         runs-on: [ubuntu-20.04, ubuntu-20.04, ubuntu-20.04]
     runs-on: ${{ matrix.runs-on }}
     env:
-      TARANTOOL_CACHE_KEY_SUFFIX: -${{ github.run_id }}
+      TARANTOOL_CACHE_KEY_SUFFIX: -B-${{ github.run_id }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Tarantool

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ steps:
   - run: .rocks/bin/luatest -v
 ```
 
+### Install a nightly build
+
+```yaml
+steps:
+  - uses: actions/checkout@v2
+  - uses: tarantool/setup-tarantool@v1
+    with:
+      tarantool-version: '2.6'
+      nightly-build: true
+```
+
 # License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ branding:
 inputs:
   tarantool-version:
     description: Tarantool version
+  nightly-build:
+    description: Whether to install a nightly build
+    required: false
+    default: false
   cache-key:
     description: Deprecated. Custom key used for APT packages caching
     required: false

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -3400,7 +3400,9 @@ const exec = __importStar(__webpack_require__(986));
 const io = __importStar(__webpack_require__(1));
 const path = __importStar(__webpack_require__(622));
 const fs = __importStar(__webpack_require__(747));
-const baseUrl = 'https://download.tarantool.org/tarantool/release/' +
+const nightlyBuild = (core.getInput('nightly-build') || 'false').toUpperCase() === 'TRUE';
+const baseUrl = 'https://download.tarantool.org/tarantool/' +
+    (nightlyBuild ? '' : 'release/') +
     core.getInput('tarantool-version', { required: true });
 async function capture(cmd, options) {
     let output = '';

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,11 @@ import * as io from '@actions/io'
 import * as path from 'path'
 import * as fs from 'fs'
 
+const nightlyBuild =
+  (core.getInput('nightly-build') || 'false').toUpperCase() === 'TRUE'
 const baseUrl =
-  'https://download.tarantool.org/tarantool/release/' +
+  'https://download.tarantool.org/tarantool/' +
+  (nightlyBuild ? '' : 'release/') +
   core.getInput('tarantool-version', {required: true})
 
 interface CaptureOptions {


### PR DESCRIPTION
```yaml
steps:
  - uses: actions/checkout@v2
  - uses: tarantool/setup-tarantool@v1
    with:
      tarantool-version: '2.6'
      nightly-build: true
```

Close #9 