### PR TITLE
feature: support 2.10+ releases

### DIFF
--- a/.github/actions/latest-version/action.yml
+++ b/.github/actions/latest-version/action.yml
@@ -24,6 +24,12 @@
 #   # ---> 1.10.13-0
 #   - run: echo ${{ steps.latest-version.outputs.git-describe }}
 #   # ---> 1.10.13-0-g1d2c5aad5
+#
+# Caution: It works smoothly only for 1.10/2.8, but not for 2.10+
+# due to changes in the package versioning (see the new release
+# policy document, [1]).
+#
+# [1]: https://github.com/tarantool/tarantool/discussions/6182
 
 name: 'Latest tarantool version'
 description: 'Get latest tarantool version of given release series'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -301,3 +301,52 @@ jobs:
         with:
           tarantool-version: '${{ steps.latest-version.outputs.git-describe }}'
           from-cache: true
+
+  # This test case installs tarantool of series-2 using
+  # one/two/three digit version specifier.
+  #
+  # It performs the following steps and checks.
+  #
+  # - install 2/2.10/2.10.0
+  #   - checks: version, non-cached
+  # - uninstall tarantool
+  # - install 2/2.10/2.10.0
+  #   - checks: version, cached
+  test-series-2:
+    strategy:
+      fail-fast: false
+      matrix:
+        tarantool:
+          - '2'
+          - '2.10'
+          - '2.10.0'
+    runs-on: ubuntu-latest
+    env:
+      # github.run_id is the same across different jobs created
+      # from the same matrix.
+      TARANTOOL_CACHE_KEY_SUFFIX: -G-${{ matrix.tarantool }}-${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install ${{ matrix.tarantool }} (non-cached)
+        uses: ./
+        with:
+          tarantool-version: '${{ matrix.tarantool }}'
+
+      - uses: ./.github/actions/verify-version
+        with:
+          tarantool-version: '${{ matrix.tarantool }}'
+          from-cache: false
+
+      - name: Uninstall tarantool
+        run: sudo apt-get -y remove tarantool tarantool-dev tarantool-common
+
+      - name: Install ${{ matrix.tarantool }} (cached)
+        uses: ./
+        with:
+          tarantool-version: '${{ matrix.tarantool }}'
+
+      - uses: ./.github/actions/verify-version
+        with:
+          tarantool-version: '${{ matrix.tarantool }}'
+          from-cache: true


### PR DESCRIPTION
## Background

The new release policy (see https://github.com/tarantool/tarantool/discussions/6182) is in effect since Tarantool 2.10 and changes several things, including:

1. Repositories layout.
   - The new release series naming: `series-2` instead of `2.10`, `2.11` and so on.
   - The new `pre-release` repository.
   - No nightly builds (`live` repository).
2. Versioning.
   - Three digit versions for release builds: `2.10.0` instead of `2.10.0.0`.
   - `alpha`, `beta`, `rc` marks in pre-release tarantool versions.

## Usage

This commit offers support of 2.10+ *releases* and leaves pre-releases unsupported (it is tracked in #23).

The usage is quite straightforward:

```yaml
steps:
  - uses: actions/checkout@v2
  - uses: tarantool/setup-tarantool@v1
    with:
      tarantool-version: '2.10.0' # or '2.10', or just '2'
```

The latest 2.10.X version will be installed for `tarantool-version: '2.10'`. The latest 2.X.Y version will be installed for `tarantool-version: '2'`.

See notes on the implementatoin details in the commit message.

Fixes #19