### PR TITLE
ci: add tarantool 2.10 into the basic test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
           - '2.7'
           - '2.8'
           - '2.9'
+          - '2.10'
         nightly: [false]
         include:
         - {runs-on: ubuntu-20.04, tarantool: '1.10', nightly: true}


### PR DESCRIPTION
It is already tested in the separate 'test-series-2' job below, but it
is convenient to have actual list of tarantool versions in the basic
test as well.