### PR TITLE
ci: run testing on Ubuntu Jammy (22.04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,15 @@ jobs:
           - '2.10'
         nightly: [false]
         include:
+        # We have Ubuntu Jammy (22.04) packages only for 2.10 at
+        # the moment of adding this code. There is commit
+        # 1.10.13-9-g2d23c9d9c, but 1.10.14 is not released yet.
+        # And there is some infrastructure problem with Jammy
+        # packages in the live/1.10 repository.
+        #
+        # Anyway, 2.10 is okay to test the action of Jammy runner,
+        # so just use it.
+        - {runs-on: ubuntu-22.04, tarantool: '2.10', nightly: false}
         - {runs-on: ubuntu-20.04, tarantool: '1.10', nightly: true}
         - {runs-on: ubuntu-18.04, tarantool: '1.10', nightly: true}
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
In May 2022 GitHub announced beta support of Ubuntu Jammy runners (see https://github.com/actions/virtual-environments/issues/5490). We should ensure that our action works here without problems.