### PR TITLE
meta: use node16 instead of node12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: Deprecated. Custom key used for APT packages caching
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: dist/index.js


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/