### PR TITLE
readme: update versions in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This action will set up [Tarantool](https://www.tarantool.io) environment and **
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: tarantool/setup-tarantool@v1
+  - uses: tarantool/setup-tarantool@v2
     with:
       tarantool-version: '2.10'
   - run: tarantoolctl rocks install luatest
@@ -29,7 +29,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: tarantool/setup-tarantool@v1
+  - uses: tarantool/setup-tarantool@v2
     with:
       tarantool-version: '2.10.4'
 ```
@@ -41,7 +41,7 @@ steps:
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: tarantool/setup-tarantool@v1
+  - uses: tarantool/setup-tarantool@v2
     with:
       tarantool-version: '2.6'  # or, say, '2.6.1.0' for exact version
       nightly-build: true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ steps:
   - uses: actions/checkout@v3
   - uses: tarantool/setup-tarantool@v1
     with:
-      tarantool-version: '2.6'
+      tarantool-version: '2.10'
   - run: tarantoolctl rocks install luatest
   - run: tarantoolctl rocks make
   - run: .rocks/bin/luatest -v
@@ -31,10 +31,12 @@ steps:
   - uses: actions/checkout@v3
   - uses: tarantool/setup-tarantool@v1
     with:
-      tarantool-version: '2.6.1'
+      tarantool-version: '2.10.4'
 ```
 
 ### Install a nightly build
+
+*Important:* nightly builds are not available for 2.10.0 and newer.
 
 ```yaml
 steps:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This action will set up [Tarantool](https://www.tarantool.io) environment and **
 
 ```yaml
 steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
   - uses: tarantool/setup-tarantool@v1
     with:
       tarantool-version: '2.6'
@@ -28,7 +28,7 @@ steps:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
   - uses: tarantool/setup-tarantool@v1
     with:
       tarantool-version: '2.6.1'
@@ -38,7 +38,7 @@ steps:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
   - uses: tarantool/setup-tarantool@v1
     with:
       tarantool-version: '2.6'  # or, say, '2.6.1.0' for exact version


### PR DESCRIPTION
It is mainly to don't let users be in a truble due to upcoming switch to node16 (summer 2023).

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/