### PR TITLE
ci: switch to actions/checkout@v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     env:
       TARANTOOL_CACHE_KEY_SUFFIX: -A-${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - id: get-latest
         run: |
@@ -95,7 +95,7 @@ jobs:
     env:
       TARANTOOL_CACHE_KEY_SUFFIX: -B-${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Tarantool
         uses: ./
         with:
@@ -118,7 +118,7 @@ jobs:
     env:
       TARANTOOL_CACHE_KEY_SUFFIX: -C-${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - id: latest-version
         uses: ./.github/actions/latest-version
@@ -175,7 +175,7 @@ jobs:
     env:
       TARANTOOL_CACHE_KEY_SUFFIX: -D-${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - id: latest-version
         uses: ./.github/actions/latest-version
@@ -221,7 +221,7 @@ jobs:
     env:
       TARANTOOL_CACHE_KEY_SUFFIX: -E-${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - id: latest-version
         uses: ./.github/actions/latest-version
@@ -268,7 +268,7 @@ jobs:
     env:
       TARANTOOL_CACHE_KEY_SUFFIX: -F-${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - id: latest-version
         uses: ./.github/actions/latest-version
@@ -336,7 +336,7 @@ jobs:
       # from the same matrix.
       TARANTOOL_CACHE_KEY_SUFFIX: -G-${{ matrix.tarantool }}-${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install ${{ matrix.tarantool }} (non-cached)
         uses: ./


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/