### PR TITLE
bugfix: verify presence of the given version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -359,3 +359,23 @@ jobs:
         with:
           tarantool-version: '${{ matrix.tarantool }}'
           from-cache: true
+
+  # There is no 1.10.999 build. Verify that an attempt to install
+  # it fails.
+  test-unknown-version:
+    runs-on: ubuntu-latest
+    env:
+      TARANTOOL_CACHE_KEY_SUFFIX: -H-${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Attempt to install 1.10.999 (expect failure)
+        uses: ./
+        with:
+          tarantool-version: '1.10.999'
+        continue-on-error: true
+        id: install
+
+      - name: Verify that the previous step fails
+        run: |
+          [ "${{ steps.install.outcome }}" = "failure" ]

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -62549,6 +62549,10 @@ async function run_linux() {
         const baseUrl = construct_base_url();
         core.startGroup(`Checking latest tarantool ${tarantool_version} version`);
         const version = await latest_version(tarantool_version);
+        if (version == '') {
+            throw new Error(`There is no tarantool ${tarantool_version} for ` +
+                `${distro_id} ${distro}`);
+        }
         core.info(`${version}`);
         core.endGroup();
         if (core.getInput('cache-key')) {

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -62542,106 +62542,105 @@ function dpkg_is_file_included(dpkgConfig, filepath) {
     return included;
 }
 async function run_linux() {
-    try {
-        const distro = await lsb_release();
-        const distro_id = (await lsb_release_id()).toLowerCase();
-        const cache_dir = 'cache-tarantool';
-        const baseUrl = construct_base_url();
-        core.startGroup(`Checking latest tarantool ${tarantool_version} version`);
-        const version = await latest_version(tarantool_version);
-        if (version == '') {
-            throw new Error(`There is no tarantool ${tarantool_version} for ` +
-                `${distro_id} ${distro}`);
-        }
-        core.info(`${version}`);
-        core.endGroup();
-        if (core.getInput('cache-key')) {
-            core.warning("Setup-tarantool input 'cache-key' is deprecated");
-        }
-        let cache_key = `tarantool-setup-${distro}-${version}`;
-        // This for testing only
-        cache_key += process.env['TARANTOOL_CACHE_KEY_SUFFIX'] || '';
-        if (await cache.restoreCache([cache_dir], cache_key)) {
-            core.info(`Cache restored from key: ${cache_key}`);
-            await exec.exec(`sudo rsync -aK "${cache_dir}/" /`);
-            await io.rmRF(cache_dir);
-            return;
-        }
-        else {
-            core.info(`Cache not found for input key: ${cache_key}`);
-        }
-        await core.group('Adding gpg key', async () => {
-            const response = await http_get(baseUrl + '/gpgkey');
-            if (response.message.statusCode !== 200) {
-                throw new Error(`server replied ${response.message.statusCode}`);
-            }
-            const gpgkey = Buffer.from(await response.readBody());
-            await exec.exec('sudo apt-key add - ', [], { input: gpgkey });
-        });
-        await core.group('Setting up repository', async () => {
-            await exec.exec('sudo tee /etc/apt/sources.list.d/tarantool.list', [], {
-                input: Buffer.from(`deb ${baseUrl}/${distro_id}/ ${distro} main\n`)
-            });
-        });
-        await core.group('Running apt-get update', async () => {
-            await exec.exec('sudo apt-get update');
-        });
-        core.startGroup('Installing tarantool');
-        const dpkg_before = await dpkg_list();
-        await exec.exec(`sudo apt-get install -y tarantool=${version}* tarantool-dev=${version}*`);
-        const dpkg_after = await dpkg_list();
-        const dpkg_diff = Array.from(dpkg_after.values()).filter(pkg => !dpkg_before.has(pkg));
-        core.endGroup();
-        core.info('Caching APT packages: ' + dpkg_diff.join(', '));
-        for (const pkg of dpkg_diff) {
-            const dpkgConfig = dpkg_read_config();
-            const output = await capture(`sudo dpkg -L ${pkg}`, { silent: true });
-            const files = output
-                .split('\n')
-                .filter(f => dpkg_is_file_included(dpkgConfig, f))
-                .filter(f => {
-                try {
-                    return fs.statSync(f).isFile();
-                }
-                catch (err) {
-                    throw new Error(`Error while checking file ${f} from package ${pkg}: ${err}`);
-                }
-            });
-            for (const f of files) {
-                const dest = path.join(cache_dir, path.dirname(f));
-                await io.mkdirP(dest);
-                await io.cp(f, dest);
-            }
-        }
-        try {
-            await cache.saveCache([cache_dir], cache_key);
-            core.info(`Cache saved with key: ${cache_key}`);
-        }
-        catch (error) {
-            if (error instanceof Error) {
-                core.warning(error.message);
-            }
-            core.warning(`Saving cache failed, but it's not crucial`);
-        }
+    const distro = await lsb_release();
+    const distro_id = (await lsb_release_id()).toLowerCase();
+    const cache_dir = 'cache-tarantool';
+    const baseUrl = construct_base_url();
+    core.startGroup(`Checking latest tarantool ${tarantool_version} version`);
+    const version = await latest_version(tarantool_version);
+    if (version == '') {
+        throw new Error(`There is no tarantool ${tarantool_version} for ` +
+            `${distro_id} ${distro}`);
+    }
+    core.info(`${version}`);
+    core.endGroup();
+    if (core.getInput('cache-key')) {
+        core.warning("Setup-tarantool input 'cache-key' is deprecated");
+    }
+    let cache_key = `tarantool-setup-${distro}-${version}`;
+    // This for testing only
+    cache_key += process.env['TARANTOOL_CACHE_KEY_SUFFIX'] || '';
+    if (await cache.restoreCache([cache_dir], cache_key)) {
+        core.info(`Cache restored from key: ${cache_key}`);
+        await exec.exec(`sudo rsync -aK "${cache_dir}/" /`);
         await io.rmRF(cache_dir);
+        return;
+    }
+    else {
+        core.info(`Cache not found for input key: ${cache_key}`);
+    }
+    await core.group('Adding gpg key', async () => {
+        const response = await http_get(baseUrl + '/gpgkey');
+        if (response.message.statusCode !== 200) {
+            throw new Error(`server replied ${response.message.statusCode}`);
+        }
+        const gpgkey = Buffer.from(await response.readBody());
+        await exec.exec('sudo apt-key add - ', [], { input: gpgkey });
+    });
+    await core.group('Setting up repository', async () => {
+        await exec.exec('sudo tee /etc/apt/sources.list.d/tarantool.list', [], {
+            input: Buffer.from(`deb ${baseUrl}/${distro_id}/ ${distro} main\n`)
+        });
+    });
+    await core.group('Running apt-get update', async () => {
+        await exec.exec('sudo apt-get update');
+    });
+    core.startGroup('Installing tarantool');
+    const dpkg_before = await dpkg_list();
+    await exec.exec(`sudo apt-get install -y tarantool=${version}* tarantool-dev=${version}*`);
+    const dpkg_after = await dpkg_list();
+    const dpkg_diff = Array.from(dpkg_after.values()).filter(pkg => !dpkg_before.has(pkg));
+    core.endGroup();
+    core.info('Caching APT packages: ' + dpkg_diff.join(', '));
+    for (const pkg of dpkg_diff) {
+        const dpkgConfig = dpkg_read_config();
+        const output = await capture(`sudo dpkg -L ${pkg}`, { silent: true });
+        const files = output
+            .split('\n')
+            .filter(f => dpkg_is_file_included(dpkgConfig, f))
+            .filter(f => {
+            try {
+                return fs.statSync(f).isFile();
+            }
+            catch (err) {
+                throw new Error(`Error while checking file ${f} from package ${pkg}: ${err}`);
+            }
+        });
+        for (const f of files) {
+            const dest = path.join(cache_dir, path.dirname(f));
+            await io.mkdirP(dest);
+            await io.cp(f, dest);
+        }
+    }
+    try {
+        await cache.saveCache([cache_dir], cache_key);
+        core.info(`Cache saved with key: ${cache_key}`);
     }
     catch (error) {
+        if (error instanceof Error) {
+            core.warning(error.message);
+        }
+        core.warning(`Saving cache failed, but it's not crucial`);
+    }
+    await io.rmRF(cache_dir);
+}
+async function run() {
+    if (process.platform !== 'linux') {
+        core.setFailed(`Action doesn't support ${process.platform} platform`);
+        return;
+    }
+    await run_linux()
+        .then(_ => {
+        return exec.exec('tarantool --version');
+    })
+        .catch(error => {
         if (error instanceof Error) {
             core.setFailed(error.message);
         }
         else {
             core.setFailed(`No error message`);
         }
-    }
-}
-async function run() {
-    if (process.platform === 'linux') {
-        await run_linux();
-    }
-    else {
-        core.setFailed(`Action doesn't support ${process.platform} platform`);
-    }
-    await exec.exec('tarantool --version');
+    });
 }
 exports.run = run;
 // Export core.setOutput() to use in testing of setup-tarantool.

--- a/src/main.ts
+++ b/src/main.ts
@@ -276,6 +276,12 @@ async function run_linux(): Promise<void> {
 
     core.startGroup(`Checking latest tarantool ${tarantool_version} version`)
     const version = await latest_version(tarantool_version)
+    if (version == '') {
+      throw new Error(
+        `There is no tarantool ${tarantool_version} for ` +
+          `${distro_id} ${distro}`
+      )
+    }
     core.info(`${version}`)
     core.endGroup()
     if (core.getInput('cache-key')) {


### PR DESCRIPTION
The action installs tarantool using the following command.

```sh
sudo apt-get install -y tarantool=${version}* tarantool-dev=${version}*
```

If there is no exactly matching version, `apt-get` installs an available one.

For example, Ubuntu Jammy (22.04) has tarantool-2.6.0 in distro's repository and an attempt to install a non-existing tarantool version gives tarantool-2.6.0.

This behavior makes things especially confusing when the `ubuntu-latest` [runner label][1] changes its meaning. For example, when `ubuntu-latest` meant Ubuntu Focal (20.04) the action successfully installs tarantool-1.10.6. Later, `ubuntu-latest` was updated to Ubuntu Jammy (22.04) and the same action invocation installs 2.6.0, because there is no 1.10.6 package for Ubuntu Jammy.

After this patchset such an update doesn't lead to installation of an unexpected tarantool version: it leads to an explicit error.

The patchset also eliminates the 'unable to locate executable file' error after failed attempt to install tarantool. It makes the error diagnostics more clear.

Part of #36

[1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners