### PR TITLE
git: mark dist/main/index.js as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/main/index.js linguist-generated=true


### PR DESCRIPTION
It instructs GitHub to don't show a diff for this file by default.

https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github