### PR TITLE
bugfix: fix tarantoolctl rocks on 1.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -364,3 +364,32 @@ jobs:
       - name: Verify that the previous step fails
         run: |
           [ "${{ steps.install.outcome }}" = "failure" ]
+
+  test-rocks:
+    # Ubuntu Jammy (22.04) has tarantool-2.6.0 in its repository.
+    # The test verifies that tarantool-common-2.6.0 is not pulled
+    # as a dependency, so this particular Ubuntu version is
+    # acquired explicitly.
+    runs-on: ubuntu-22.04
+    env:
+      TARANTOOL_CACHE_KEY_SUFFIX: -I-${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Verify non-cached installation. The cached one has exactly
+      # same luarocks, no need to verify it.
+      - name: Install 1.10
+        uses: ./
+        with:
+          tarantool-version: '1.10'
+
+      # If luarocks 3 is installed instead of luarocks 2, this
+      # command fails with the following error message.
+      #
+      # > module 'luarocks.core.cfg' not found
+      #
+      # See https://github.com/tarantool/tarantool/issues/5429 for
+      # details.
+      - name: Verify tarantoolctl rocks
+        run: |
+          tarantoolctl rocks list

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -62617,7 +62617,15 @@ async function run_linux() {
     });
     core.startGroup('Installing tarantool');
     const dpkg_before = await dpkg_list();
-    await exec.exec(`sudo apt-get install -y tarantool=${version}* tarantool-dev=${version}*`);
+    /*
+     * The series-3 repository doesn't offer the tarantool-common
+     * package.
+     */
+    let pkgs = [`tarantool=${version}*`, `tarantool-dev=${version}*`];
+    if (tarantool_version_major() < 3) {
+        pkgs.push(`tarantool-common=${version}*`);
+    }
+    await exec.exec('sudo apt-get install -y ' + pkgs.join(' '));
     const dpkg_after = await dpkg_list();
     const dpkg_diff = Array.from(dpkg_after.values()).filter(pkg => !dpkg_before.has(pkg));
     core.endGroup();

--- a/src/main.ts
+++ b/src/main.ts
@@ -353,9 +353,17 @@ async function run_linux(): Promise<void> {
   core.startGroup('Installing tarantool')
 
   const dpkg_before = await dpkg_list()
-  await exec.exec(
-    `sudo apt-get install -y tarantool=${version}* tarantool-dev=${version}*`
-  )
+
+  /*
+   * The series-3 repository doesn't offer the tarantool-common
+   * package.
+   */
+  let pkgs = [`tarantool=${version}*`, `tarantool-dev=${version}*`]
+  if (tarantool_version_major() < 3) {
+    pkgs.push(`tarantool-common=${version}*`)
+  }
+  await exec.exec('sudo apt-get install -y ' + pkgs.join(' '))
+
   const dpkg_after = await dpkg_list()
 
   const dpkg_diff: Array<string> = Array.from(dpkg_after.values()).filter(


### PR DESCRIPTION
The fix is to install appropriate version of the `tarantool-common` package.

Fixes #36
Fixes #37